### PR TITLE
perf: streaming hot path — Promise-churn elimination (1.75-1.85x parser-level on context-cached workloads)

### DIFF
--- a/lib/ContextTree.ts
+++ b/lib/ContextTree.ts
@@ -1,6 +1,16 @@
 import type { JsonLdContextNormalized } from 'jsonld-context-parser';
 
 /**
+ * A context lookup result, exposing the context promise and,
+ * when it has already settled, its resolved value.
+ */
+export interface IContextTreeEntry {
+  context: Promise<JsonLdContextNormalized>;
+  resolved: JsonLdContextNormalized | null;
+  depth: number;
+}
+
+/**
  * A tree structure that holds all contexts,
  * based on their position in the JSON object.
  *
@@ -9,20 +19,51 @@ import type { JsonLdContextNormalized } from 'jsonld-context-parser';
 export class ContextTree {
   private readonly subTrees: Record<string, ContextTree> = {};
   private context: Promise<JsonLdContextNormalized> | null = null;
+  // The resolved value of `context`, once (and only while) it is known.
+  private contextResolved: JsonLdContextNormalized | null = null;
 
-  public getContext(keys: string[], index = 0): Promise<{ context: JsonLdContextNormalized; depth: number }> | null {
-    // Walk the tree using an index into `keys` rather than `[ head, ...tail ]`,
-    // which would allocate a fresh `tail` array on every recursive call.
-    if (index < keys.length) {
-      const subTree = this.subTrees[keys[index]];
-      if (subTree) {
-        const subContext = subTree.getContext(keys, index + 1);
-        if (subContext) {
-          return subContext.then(({ context, depth }) => ({ context, depth: depth + 1 }));
-        }
+  /**
+   * Find the deepest node holding a context along `keys[index..end)`, together with its depth.
+   *
+   * This iterative walk performs no allocations,
+   * and exposes the already-resolved context value when it is known,
+   * which allows callers to avoid Promise churn on hot paths.
+   *
+   * @param keys The path of keys to look along.
+   * @param index The inclusive lower bound within `keys` to start walking from (defaults to 0).
+   * @param end The exclusive upper bound within `keys` to walk (defaults to `keys.length`).
+   * @return {IContextTreeEntry | null} The deepest context entry at or above the path, if any.
+   */
+  public lookup(keys: string[], index = 0, end: number = keys.length): IContextTreeEntry | null {
+    // eslint-disable-next-line ts/no-this-alias
+    let node: ContextTree = this;
+    let found: ContextTree | null = this.context ? this : null;
+    let foundDepth = 0;
+    let depth = 0;
+    for (let i = index; i < end; i++) {
+      const subTree: ContextTree | undefined = node.subTrees[keys[i]];
+      if (!subTree) {
+        break;
+      }
+      node = subTree;
+      depth++;
+      if (node.context) {
+        found = node;
+        foundDepth = depth;
       }
     }
-    return this.context ? this.context.then(context => ({ context, depth: 0 })) : null;
+    return found ? { context: found.context!, resolved: found.contextResolved, depth: foundDepth } : null;
+  }
+
+  public getContext(keys: string[], index = 0): Promise<{ context: JsonLdContextNormalized; depth: number }> | null {
+    const entry = this.lookup(keys, index);
+    if (!entry) {
+      return null;
+    }
+    if (entry.resolved) {
+      return Promise.resolve({ context: entry.resolved, depth: entry.depth });
+    }
+    return entry.context.then(context => ({ context, depth: entry.depth }));
   }
 
   /**
@@ -39,26 +80,42 @@ export class ContextTree {
    * @return {boolean} True if a context exists at or above the given path.
    */
   public hasContext(keys: string[], index = 0, end: number = keys.length): boolean {
-    if (index < end) {
-      const subTree = this.subTrees[keys[index]];
-      if (subTree && subTree.hasContext(keys, index + 1, end)) {
-        return true;
-      }
-    }
-    return Boolean(this.context);
+    return this.lookup(keys, index, end) !== null;
   }
 
-  public setContext(keys: any[], context: Promise<JsonLdContextNormalized> | null): void {
-    if (keys.length === 0) {
-      this.context = context;
-    } else {
-      // eslint-disable-next-line ts/no-unsafe-assignment
-      const [ head, ...tail ] = keys;
-      let subTree = this.subTrees[head];
+  public setContext(
+    keys: any[],
+    context: Promise<JsonLdContextNormalized> | JsonLdContextNormalized | null,
+  ): void {
+    // eslint-disable-next-line ts/no-this-alias
+    let node: ContextTree = this;
+    for (const key of keys) {
+      let subTree = node.subTrees[key];
       if (!subTree) {
-        subTree = this.subTrees[head] = new ContextTree();
+        subTree = node.subTrees[key] = new ContextTree();
       }
-      subTree.setContext(tail, context);
+      node = subTree;
+    }
+    if (context && typeof (<Promise<JsonLdContextNormalized>>context).then !== 'function') {
+      // An already-resolved context can be recorded synchronously.
+      node.context = Promise.resolve(<JsonLdContextNormalized>context);
+      node.contextResolved = <JsonLdContextNormalized>context;
+    } else {
+      const contextPromise = <Promise<JsonLdContextNormalized> | null>context;
+      node.context = contextPromise;
+      node.contextResolved = null;
+      if (contextPromise) {
+        // Record the resolved value (only if the slot still holds this exact promise),
+        // so that later lookups can access it without going through the microtask queue.
+        // Rejections are left to be handled by whoever consumes the context promise.
+        contextPromise.then((value) => {
+          if (node.context === contextPromise) {
+            node.contextResolved = value;
+          }
+        }, () => {
+          // Ignored: the consumer of the context promise is responsible for error handling.
+        });
+      }
     }
   }
 

--- a/lib/ContextTree.ts
+++ b/lib/ContextTree.ts
@@ -10,18 +10,42 @@ export class ContextTree {
   private readonly subTrees: Record<string, ContextTree> = {};
   private context: Promise<JsonLdContextNormalized> | null = null;
 
-  public getContext(keys: string[]): Promise<{ context: JsonLdContextNormalized; depth: number }> | null {
-    if (keys.length > 0) {
-      const [ head, ...tail ] = keys;
-      const subTree = this.subTrees[head];
+  public getContext(keys: string[], index = 0): Promise<{ context: JsonLdContextNormalized; depth: number }> | null {
+    // Walk the tree using an index into `keys` rather than `[ head, ...tail ]`,
+    // which would allocate a fresh `tail` array on every recursive call.
+    if (index < keys.length) {
+      const subTree = this.subTrees[keys[index]];
       if (subTree) {
-        const subContext = subTree.getContext(tail);
+        const subContext = subTree.getContext(keys, index + 1);
         if (subContext) {
           return subContext.then(({ context, depth }) => ({ context, depth: depth + 1 }));
         }
       }
     }
     return this.context ? this.context.then(context => ({ context, depth: 0 })) : null;
+  }
+
+  /**
+   * Synchronously check whether {@link #getContext} would return a context (i.e. a non-null value)
+   * for the given path.
+   *
+   * This is a pure boolean mirror of {@link #getContext}'s non-null semantics. It is used for
+   * truthiness tests where only the *presence* of a context matters, avoiding the intermediate
+   * Promise (and its `.then` closure) that {@link #getContext} allocates for that check.
+   *
+   * @param keys The path of keys to check.
+   * @param index The current offset into `keys` (defaults to 0).
+   * @param end The exclusive upper bound within `keys` to walk (defaults to `keys.length`).
+   * @return {boolean} True if a context exists at or above the given path.
+   */
+  public hasContext(keys: string[], index = 0, end: number = keys.length): boolean {
+    if (index < end) {
+      const subTree = this.subTrees[keys[index]];
+      if (subTree && subTree.hasContext(keys, index + 1, end)) {
+        return true;
+      }
+    }
+    return Boolean(this.context);
   }
 
   public setContext(keys: any[], context: Promise<JsonLdContextNormalized> | null): void {

--- a/lib/JsonLdParser.ts
+++ b/lib/JsonLdParser.ts
@@ -471,18 +471,26 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
       // eslint-disable-next-line ts/no-unsafe-assignment
       const depth = this.jsonParser.stack.length;
       // Don't parse inner nodes inside @context
+      // Build the keys stack by filling a single preallocated array with a plain loop, avoiding
+      // the per-value closure that `Array.from(..., mapFn)` would allocate on every emitted value.
       // eslint-disable-next-line ts/no-unsafe-assignment
-      const keys = Array.from({ length: depth + 1 }, (v, i) =>
-        // eslint-disable-next-line ts/no-unsafe-return
-        i === depth ? this.jsonParser.key : this.jsonParser.stack[i].key);
+      const keys: any[] = Array.from({ length: depth + 1 });
+      for (let i = 0; i < depth; i++) {
+        // eslint-disable-next-line ts/no-unsafe-assignment
+        keys[i] = this.jsonParser.stack[i].key;
+      }
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      keys[depth] = this.jsonParser.key;
 
       // eslint-disable-next-line ts/no-unsafe-argument
       if (!this.isParsingContextInner(depth)) {
         // eslint-disable-next-line ts/no-unsafe-argument
         const valueJobCb = (): Promise<void> => this.newOnValueJob(keys, value, depth, true);
         if (!this.parsingContext.streamingProfile &&
+          // Synchronous presence check over keys.slice(0, -1); avoids allocating a slice + Promise
+          // just to test for the existence of a context (see ContextTree#hasContext).
           // eslint-disable-next-line ts/no-unsafe-argument
-          !this.parsingContext.contextTree.getContext(keys.slice(0, -1))) {
+          !this.parsingContext.contextTree.hasContext(keys, 0, depth)) {
           // If an out-of-order context is allowed,
           // we have to buffer everything.
           // We store jobs for @context's and @type's separately,

--- a/lib/JsonLdParser.ts
+++ b/lib/JsonLdParser.ts
@@ -64,6 +64,9 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
   private lastKeys: any[];
   // A promise representing the last job
   private lastOnValueJob: Promise<void>;
+  // Whether the last job (and thereby the whole chain) has settled,
+  // in which case a new job can be started synchronously instead of being chained.
+  private lastOnValueJobSettled: boolean;
 
   public constructor(options?: IJsonLdParserOptions) {
     super({ readableObjectMode: true });
@@ -81,6 +84,7 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
     this.lastDepth = 0;
     this.lastKeys = [];
     this.lastOnValueJob = Promise.resolve();
+    this.lastOnValueJobSettled = true;
 
     this.attachJsonParserListeners();
 
@@ -226,11 +230,15 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
 
       // Flush the buffer for lastDepth
       // If the parent key is a special type of container, postpone flushing until that parent is handled.
-      if (await EntryHandlerContainer.isBufferableContainerHandler(
+      let bufferableContainerHandler = EntryHandlerContainer.isBufferableContainerHandler(
         this.parsingContext,
         this.lastKeys,
         this.lastDepth,
-      )) {
+      );
+      if (Util.isPromise(bufferableContainerHandler)) {
+        bufferableContainerHandler = await bufferableContainerHandler;
+      }
+      if (bufferableContainerHandler) {
         this.parsingContext.pendingContainerFlushBuffers
           .push({ depth: this.lastDepth, keys: this.lastKeys.slice(0, this.lastKeys.length) });
         flushStacks = false;
@@ -240,9 +248,17 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
     }
 
     // eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-argument
-    const key = await this.util.unaliasKeyword(keys[depth], keys, depth);
+    let key = this.util.unaliasKeywordFast(keys[depth], keys, depth);
+    if (Util.isPromise(key)) {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      key = await key;
+    }
     // eslint-disable-next-line ts/no-unsafe-assignment
-    const parentKey = await this.util.unaliasKeywordParent(keys, depth);
+    let parentKey = this.util.unaliasKeywordParentFast(keys, depth);
+    if (Util.isPromise(parentKey)) {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      parentKey = await parentKey;
+    }
     this.parsingContext.emittedStack[depth] = true;
     let handleKey = true;
 
@@ -258,8 +274,14 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
       inProperty = this.parsingContext.validationStack.at(-1)!.property;
     }
     for (let i = Math.max(1, this.parsingContext.validationStack.length - 1); i < keys.length - 1; i++) {
-      const validationResult = this.parsingContext.validationStack[i] ||
-        (this.parsingContext.validationStack[i] = await this.validateKey(keys.slice(0, i + 1), i, inProperty));
+      let validationResult = this.parsingContext.validationStack[i];
+      if (!validationResult) {
+        let validationResultNew = this.validateKey(keys.slice(0, i + 1), i, inProperty);
+        if (Util.isPromise(validationResultNew)) {
+          validationResultNew = await validationResultNew;
+        }
+        validationResult = this.parsingContext.validationStack[i] = validationResultNew;
+      }
       if (!validationResult.valid) {
         this.parsingContext.emittedStack[depth] = false;
         handleKey = false;
@@ -270,7 +292,11 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
     }
 
     // Skip further processing if this node is part of a literal
-    if (await this.util.isLiteral(keys, depth)) {
+    let literal = this.util.isLiteralFast(keys, depth);
+    if (Util.isPromise(literal)) {
+      literal = await literal;
+    }
+    if (literal) {
       handleKey = false;
     }
 
@@ -278,7 +304,11 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
     if (handleKey) {
       for (const entryHandler of JsonLdParser.ENTRY_HANDLERS) {
         // eslint-disable-next-line ts/no-unsafe-assignment
-        const testResult = await entryHandler.test(this.parsingContext, this.util, key, keys, depth);
+        let testResult = entryHandler.test(this.parsingContext, this.util, key, keys, depth);
+        if (Util.isPromise(testResult)) {
+          // eslint-disable-next-line ts/no-unsafe-assignment
+          testResult = await testResult;
+        }
         if (testResult) {
           // Pass processing over to the handler
           await entryHandler.handle(this.parsingContext, this.util, key, keys, value, depth, testResult);
@@ -442,19 +472,55 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
 
   /**
    * Check if at least one {@link IEntryHandler} validates the entry to true.
+   *
+   * The result is returned directly (not wrapped in a Promise)
+   * whenever it can be determined synchronously,
+   * and a Promise is only returned when a handler requires asynchronous work.
+   *
    * @param {any[]} keys A stack of keys.
    * @param {number} depth A depth.
    * @param {boolean} inProperty If the current depth is part of a valid property node.
-   * @return {Promise<{ valid: boolean, property: boolean }>} A promise resolving to true or false.
+   * @return {{ valid: boolean, property: boolean } | Promise<{ valid: boolean, property: boolean }>}
+   *         The validation result, possibly wrapped in a promise.
    */
-  protected async validateKey(
+  protected validateKey(
+    keys: any[],
+    depth: number,
+    inProperty: boolean,
+  ): { valid: boolean; property: boolean } | Promise<{ valid: boolean; property: boolean }> {
+    const entryHandlers = JsonLdParser.ENTRY_HANDLERS;
+    // eslint-disable-next-line unicorn/no-for-loop
+    for (let i = 0; i < entryHandlers.length; i++) {
+      const validationResult = entryHandlers[i].validate(this.parsingContext, this.util, keys, depth, inProperty);
+      if (Util.isPromise(validationResult)) {
+        // Continue asynchronously from the current handler.
+        return this.validateKeyAsyncFrom(validationResult, i, keys, depth, inProperty);
+      }
+      if (validationResult) {
+        return { valid: true, property: inProperty || entryHandlers[i].isPropertyHandler() };
+      }
+    }
+    return { valid: false, property: false };
+  }
+
+  /**
+   * The asynchronous continuation of {@link JsonLdParser#validateKey},
+   * starting at handler `index` for which the pending validation result is given.
+   */
+  protected async validateKeyAsyncFrom(
+    pendingValidationResult: Promise<boolean>,
+    index: number,
     keys: any[],
     depth: number,
     inProperty: boolean,
   ): Promise<{ valid: boolean; property: boolean }> {
-    for (const entryHandler of JsonLdParser.ENTRY_HANDLERS) {
-      if (await entryHandler.validate(this.parsingContext, this.util, keys, depth, inProperty)) {
-        return { valid: true, property: inProperty || entryHandler.isPropertyHandler() };
+    const entryHandlers = JsonLdParser.ENTRY_HANDLERS;
+    if (await pendingValidationResult) {
+      return { valid: true, property: inProperty || entryHandlers[index].isPropertyHandler() };
+    }
+    for (let i = index + 1; i < entryHandlers.length; i++) {
+      if (await entryHandlers[i].validate(this.parsingContext, this.util, keys, depth, inProperty)) {
+        return { valid: true, property: inProperty || entryHandlers[i].isPropertyHandler() };
       }
     }
     return { valid: false, property: false };
@@ -508,19 +574,55 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
           }
         } else {
           // Make sure that our value jobs are chained synchronously
-          this.lastOnValueJob = this.lastOnValueJob.then(valueJobCb);
+          this.enqueueValueJob(valueJobCb);
         }
 
         // Execute all buffered jobs on deeper levels
         if (!this.parsingContext.streamingProfile && depth === 0) {
-          this.lastOnValueJob = this.lastOnValueJob
-            .then(() => this.executeBufferedJobs());
+          this.enqueueValueJob(() => this.executeBufferedJobs());
         }
       }
     };
     this.jsonParser.onError = (error: Error) => {
       this.emit('error', error);
     };
+  }
+
+  /**
+   * Append the given job to the value job chain.
+   *
+   * If the previous job chain has fully settled, the new job is started immediately:
+   * this executes all of its synchronously-completable work inline,
+   * instead of unconditionally deferring it to a later microtask
+   * (and paying the extra promise-adoption microtasks of `.then(job)`).
+   *
+   * Jobs are still guaranteed to execute strictly sequentially,
+   * and a rejected job still causes all later chained jobs to be skipped,
+   * with the rejection being reported through {@link JsonLdParser#lastOnValueJob}.
+   *
+   * @param job A callback producing the job promise.
+   */
+  protected enqueueValueJob(job: () => Promise<void>): void {
+    if (this.lastOnValueJobSettled) {
+      this.lastOnValueJobSettled = false;
+      this.lastOnValueJob = job();
+    } else {
+      this.lastOnValueJob = this.lastOnValueJob.then(job);
+    }
+    const jobPromise = this.lastOnValueJob;
+    jobPromise.then(() => {
+      // Only mark the chain as settled if no further job was appended in the meantime.
+      if (this.lastOnValueJob === jobPromise) {
+        this.lastOnValueJobSettled = true;
+      }
+    }, () => {
+      // Deliberately keep the chain unsettled on failure:
+      // later jobs must chain onto the rejected promise (and thereby be skipped),
+      // exactly as they would without the settled-tracking fast path.
+      // The rejection itself is reported through `lastOnValueJob` (see `_transform`),
+      // this handler only prevents the settled-tracking promise
+      // from being reported as an unhandled rejection.
+    });
   }
 
   /**
@@ -558,14 +660,27 @@ export class JsonLdParser extends Transform implements RDF.Sink<EventEmitter, RD
 
     for (const job of this.contextAwaitingJobs) {
       // Also capture @type with array values
-      if ((await this.util.unaliasKeyword(job.keys[job.depth], job.keys, job.depth, true)) === '@type' ||
-        (typeof job.keys[job.depth] === 'number' &&
-          (await this.util.unaliasKeyword(
-            job.keys[job.depth - 1],
-            job.keys,
-            job.depth - 1,
-            true,
-          )) === '@type')) {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      let jobKey = this.util.unaliasKeywordFast(job.keys[job.depth], job.keys, job.depth, true);
+      if (Util.isPromise(jobKey)) {
+        // eslint-disable-next-line ts/no-unsafe-assignment
+        jobKey = await jobKey;
+      }
+      let jobParentKey: any;
+      if (jobKey !== '@type' && typeof job.keys[job.depth] === 'number') {
+        // eslint-disable-next-line ts/no-unsafe-assignment
+        jobParentKey = this.util.unaliasKeywordFast(
+          job.keys[job.depth - 1],
+          job.keys,
+          job.depth - 1,
+          true,
+        );
+        if (Util.isPromise(jobParentKey)) {
+          // eslint-disable-next-line ts/no-unsafe-assignment
+          jobParentKey = await jobParentKey;
+        }
+      }
+      if (jobKey === '@type' || jobParentKey === '@type') {
         // Remove @type from keys, because we want it to apply to parent later on
         this.typeJobs.push({ job: job.job, keys: job.keys.slice(0, -1) });
       } else {

--- a/lib/ParsingContext.ts
+++ b/lib/ParsingContext.ts
@@ -101,6 +101,9 @@ export class ParsingContext {
   public activeProcessingMode: number;
 
   private readonly parser: JsonLdParser;
+  // The resolved root context, once (and only when) it is known.
+  // This enables the synchronous context lookup fast path.
+  private rootContextResolved: JsonLdContextNormalized | null = null;
 
   public constructor(options: IParsingContextOptions) {
     // Initialize settings
@@ -149,10 +152,19 @@ export class ParsingContext {
       this.rootContext = this.parseContext(options.context, undefined, undefined, true);
       // eslint-disable-next-line ts/no-floating-promises
       void this.rootContext.then(context => this.validateContext(context));
+      // Cache the resolved root context for the synchronous lookup fast path.
+      // Rejections are left to be handled by whoever awaits `rootContext`.
+      this.rootContext.then((context) => {
+        this.rootContextResolved = context;
+      }, () => {
+        // Ignored: the consumer of the root context promise is responsible for error handling.
+      });
     } else {
-      this.rootContext = Promise.resolve(new JsonLdContextNormalized(
+      const rootContext = new JsonLdContextNormalized(
         this.baseIRI ? { '@base': this.baseIRI, '@__baseDocument': true } : {},
-      ));
+      );
+      this.rootContext = Promise.resolve(rootContext);
+      this.rootContextResolved = rootContext;
     }
   }
 
@@ -202,27 +214,87 @@ export class ParsingContext {
   }
 
   /**
+   * Compute the exclusive upper bound within `keys` that {@link ParsingContext#getContext}
+   * uses for its context lookup: trailing array (number) keys are ignored,
+   * and the given offset is subtracted.
+   * This replaces the `keys.slice()` calls that would otherwise be needed on a very hot path.
+   * @param {keys} keys The path of keys.
+   * @param {number} offset The path offset.
+   * @return {number} The exclusive upper bound within `keys` for the context lookup.
+   */
+  private static getContextLookupEnd(keys: any[], offset: number): number {
+    let end = keys.length;
+
+    // Ignore array keys at the end
+    while (typeof keys[end - 1] === 'number') {
+      end--;
+    }
+
+    // Handle offset on keys
+    return Math.max(end - offset, 0);
+  }
+
+  /**
+   * Synchronously get the context at the given path, if it can be determined
+   * without asynchronous work.
+   *
+   * This mirrors {@link ParsingContext#getContext} for the common case in which
+   * the applicable context has already been resolved and no property-scoped context
+   * (which requires an asynchronous context parse) applies.
+   *
+   * @param {keys} keys The path of keys to get the context at.
+   * @param {number} offset The path offset, defaults to 1.
+   * @return {JsonLdContextNormalized | null} The context,
+   *         or null if it can not be determined synchronously
+   *         (in which case {@link ParsingContext#getContext} must be used).
+   */
+  public tryGetContext(keys: any[], offset = 1): JsonLdContextNormalized | null {
+    const end = ParsingContext.getContextLookupEnd(keys, offset);
+
+    // Determine the closest context
+    const contextData = this.tryGetContextPropagationAware(keys, end);
+    if (!contextData) {
+      return null;
+    }
+
+    // Property-scoped contexts require an asynchronous context parse,
+    // so their presence sends us to the asynchronous path.
+    // This scan mirrors the property-scoped context loop in {@link ParsingContext#getContext}:
+    // since that loop only modifies the context after finding a first applicable
+    // property-scoped context, bailing out on the first hit is equivalent.
+    const contextRaw: IJsonLdContextNormalizedRaw = contextData.context.getContextRaw();
+    for (let i = contextData.depth; i < keys.length - offset; i++) {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      const key = keys[i];
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      const contextKeyEntry = contextRaw[key];
+      if (contextKeyEntry && typeof contextKeyEntry === 'object' && '@context' in contextKeyEntry) {
+        return null;
+      }
+    }
+
+    return contextData.context;
+  }
+
+  /**
    * Get the context at the given path.
    * @param {keys} keys The path of keys to get the context at.
    * @param {number} offset The path offset, defaults to 1.
    * @return {Promise<JsonLdContextNormalized>} A promise resolving to a context.
    */
   public async getContext(keys: any[], offset = 1): Promise<JsonLdContextNormalized> {
+    // Fast path: the common case can be answered synchronously.
+    const contextSync = this.tryGetContext(keys, offset);
+    if (contextSync) {
+      return contextSync;
+    }
+
     const keysOriginal = keys;
-
-    // Ignore array keys at the end
-    while (typeof keys.at(-1) === 'number') {
-      keys = keys.slice(0, -1);
-    }
-
-    // Handle offset on keys
-    if (offset) {
-      keys = keys.slice(0, -offset);
-    }
+    const end = ParsingContext.getContextLookupEnd(keys, offset);
 
     // Determine the closest context
     // eslint-disable-next-line ts/no-unsafe-argument
-    const contextData = await this.getContextPropagationAware(keys);
+    const contextData = await this.getContextPropagationAware(keys, end);
     const context: JsonLdContextNormalized = contextData.context;
 
     // Process property-scoped contexts (high-to-low)
@@ -272,6 +344,57 @@ export class ParsingContext {
   }
 
   /**
+   * Synchronously get the context at the given path in a propagation-aware manner,
+   * if it can be determined without asynchronous work.
+   *
+   * This mirrors the common (single-iteration) case of
+   * {@link ParsingContext#getContextPropagationAware}:
+   * the rare propagation-sensitive cases (non-propagating contexts and propagation fallbacks)
+   * are delegated to the asynchronous path by returning null.
+   *
+   * @param keys The path of keys to get the context at.
+   * @param end The exclusive upper bound within `keys` for the lookup.
+   * @return {{ context: JsonLdContextNormalized, depth: number } | null} A context and its depth,
+   *         or null if they can not be determined synchronously.
+   */
+  public tryGetContextPropagationAware(keys: any[], end: number):
+  { context: JsonLdContextNormalized; depth: number } | null {
+    // eslint-disable-next-line ts/no-unsafe-argument
+    const entry = this.contextTree.lookup(keys, 0, end);
+    let context: JsonLdContextNormalized;
+    let depth: number;
+    if (entry) {
+      if (!entry.resolved) {
+        // The applicable context is still being parsed: go through the asynchronous path.
+        return null;
+      }
+      context = entry.resolved;
+      depth = entry.depth;
+    } else {
+      if (!this.rootContextResolved) {
+        // The root context is still being parsed: go through the asynchronous path.
+        return null;
+      }
+      context = this.rootContextResolved;
+      depth = 0;
+    }
+
+    if (context.getContextRaw()['@propagate'] === false && depth !== end) {
+      if (depth > 0) {
+        // Non-propagating contexts require the full iterative logic
+        // of {@link ParsingContext#getContextPropagationAware}.
+        return null;
+      }
+
+      // Special case for root context that does not allow propagation.
+      // Fallback to empty context in that case.
+      return { context: new JsonLdContextNormalized({}), depth };
+    }
+
+    return { context, depth };
+  }
+
+  /**
    * Get the context at the given path.
    * Non-propagating contexts will be skipped,
    * unless the context at that exact depth is retrieved.
@@ -281,11 +404,13 @@ export class ParsingContext {
    * call {@link #getContext} instead.
    *
    * @param keys The path of keys to get the context at.
+   * @param end The exclusive upper bound within `keys` for the lookup, defaults to `keys.length`.
+   *            This avoids `keys.slice()` allocations on a hot path.
    * @return {Promise<{ context: JsonLdContextNormalized, depth: number }>} A context and its depth.
    */
-  public async getContextPropagationAware(keys: string[]):
+  public async getContextPropagationAware(keys: string[], end: number = keys.length):
   Promise<{ context: JsonLdContextNormalized; depth: number }> {
-    const originalDepth = keys.length;
+    const originalDepth = end;
     let contextData: { context: JsonLdContextNormalized; depth: number } | null = null;
     let hasApplicablePropertyScopedContext: boolean;
     do {
@@ -300,16 +425,19 @@ export class ParsingContext {
           // If we had a previous iteration, jump to the parent of context depth.
           // We must do this because once we get here, last context had propagation disabled,
           // so we check its first parent instead.
-          keys = keys.slice(0, contextData.depth - 1);
+          end = contextData.depth - 1;
         }
 
-        contextData = await this.contextTree.getContext(keys) ?? { context: await this.rootContext, depth: 0 };
+        const entry = this.contextTree.lookup(keys, 0, end);
+        contextData = entry ?
+            { context: entry.resolved ?? await entry.context, depth: entry.depth } :
+            { context: await this.rootContext, depth: 0 };
       }
 
       // Allow non-propagating contexts to propagate one level deeper
       // if it defines a property-scoped context that is applicable for the current key.
       // @see https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc012
-      const lastKey = keys.at(-1);
+      const lastKey = end >= 1 ? keys[end - 1] : undefined;
       if (lastKey !== undefined && lastKey in contextData.context.getContextRaw()) {
         // eslint-disable-next-line ts/no-unsafe-assignment
         const lastKeyValue = contextData.context.getContextRaw()[lastKey];

--- a/lib/ParsingContext.ts
+++ b/lib/ParsingContext.ts
@@ -227,6 +227,10 @@ export class ParsingContext {
 
     // Process property-scoped contexts (high-to-low)
     let contextRaw: IJsonLdContextNormalizedRaw = context.getContextRaw();
+    // Track whether the loop below actually reassigned `contextRaw` to a different raw object.
+    // In the common path it never does, so we can return the existing `context` (which already
+    // wraps this exact raw object) instead of allocating a redundant JsonLdContextNormalized wrapper.
+    let modified = false;
     for (let i = contextData.depth; i < keysOriginal.length - offset; i++) {
       // eslint-disable-next-line ts/no-unsafe-assignment
       const key = keysOriginal[i];
@@ -242,6 +246,7 @@ export class ParsingContext {
 
         if (propagate !== false || i === keysOriginal.length - 1 - offset) {
           contextRaw = { ...scopedContext };
+          modified = true;
 
           // Clean up final context
           delete contextRaw['@propagate'];
@@ -263,7 +268,7 @@ export class ParsingContext {
       }
     }
 
-    return new JsonLdContextNormalized(contextRaw);
+    return modified ? new JsonLdContextNormalized(contextRaw) : context;
   }
 
   /**

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -185,6 +185,20 @@ export class Util {
   }
 
   /**
+   * Check if the given value is a Promise (or thenable).
+   *
+   * This is used on hot paths to distinguish synchronously-available results
+   * from asynchronous ones, so that the Promise machinery (allocation and
+   * microtask scheduling) is only paid for when actually needed.
+   *
+   * @param value A value that is either a result or a Promise of a result.
+   * @return {boolean} If the given value is a Promise.
+   */
+  public static isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+    return Boolean(value) && typeof (<Promise<T>>value).then === 'function';
+  }
+
+  /**
    * Check if the given first array (needle) is a prefix of the given second array (haystack).
    * @param needle An array to check if it is a prefix.
    * @param haystack An array to look in.
@@ -808,9 +822,30 @@ export class Util {
     disableCache?: boolean,
     context?: JsonLdContextNormalized,
   ): Promise<any> {
+    // eslint-disable-next-line ts/no-unsafe-return
+    return this.unaliasKeywordFast(key, keys, depth, disableCache, context);
+  }
+
+  /**
+   * Variant of {@link Util#unaliasKeyword} that avoids Promise overhead when possible:
+   * the result is returned directly (not wrapped in a Promise)
+   * whenever it can be determined synchronously,
+   * and a Promise is only returned when an asynchronous context lookup is unavoidable.
+   *
+   * Since keys can never be thenables,
+   * callers can safely distinguish the two cases with {@link Util.isPromise}.
+   *
+   * @see Util#unaliasKeyword
+   */
+  public unaliasKeywordFast(
+    key: any,
+    keys: string[],
+    depth: number,
+    disableCache?: boolean,
+    context?: JsonLdContextNormalized,
+  ): any {
     // Numbers can not be an alias
     if (Number.isInteger(key)) {
-      // eslint-disable-next-line ts/no-unsafe-return
       return key;
     }
 
@@ -819,26 +854,47 @@ export class Util {
       // eslint-disable-next-line ts/no-unsafe-assignment
       const cachedUnaliasedKeyword = this.parsingContext.unaliasedKeywordCacheStack[depth];
       if (cachedUnaliasedKeyword) {
-        // eslint-disable-next-line ts/no-unsafe-return
         return cachedUnaliasedKeyword;
       }
     }
 
     if (!ContextUtil.isPotentialKeyword(key)) {
-      context = context ?? await this.parsingContext.getContext(keys);
-      // eslint-disable-next-line ts/no-unsafe-assignment
-      let unliased = context.getContextRaw()[key];
-      if (unliased && typeof unliased === 'object') {
-        // eslint-disable-next-line ts/no-unsafe-assignment
-        unliased = unliased['@id'];
+      context = context ?? this.parsingContext.tryGetContext(keys) ?? undefined;
+      if (!context) {
+        return this.parsingContext.getContext(keys)
+          // eslint-disable-next-line ts/no-unsafe-return
+          .then(asyncContext => this.unaliasKeywordWithContext(key, asyncContext, depth, disableCache));
       }
-      if (ContextUtil.isValidKeyword(unliased)) {
-        // eslint-disable-next-line ts/no-unsafe-assignment
-        key = unliased;
-      }
+
+      return this.unaliasKeywordWithContext(key, context, depth, disableCache);
     }
 
-    // eslint-disable-next-line ts/no-unsafe-return, ts/no-unsafe-assignment
+    // eslint-disable-next-line ts/no-unsafe-assignment
+    return disableCache ? key : (this.parsingContext.unaliasedKeywordCacheStack[depth] = key);
+  }
+
+  /**
+   * Un-alias the given key against the given context.
+   * This is the synchronous tail of {@link Util#unaliasKeywordFast}.
+   */
+  private unaliasKeywordWithContext(
+    key: any,
+    context: JsonLdContextNormalized,
+    depth: number,
+    disableCache?: boolean,
+  ): any {
+    // eslint-disable-next-line ts/no-unsafe-assignment
+    let unliased = context.getContextRaw()[key];
+    if (unliased && typeof unliased === 'object') {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      unliased = unliased['@id'];
+    }
+    if (ContextUtil.isValidKeyword(unliased)) {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      key = unliased;
+    }
+
+    // eslint-disable-next-line ts/no-unsafe-assignment
     return disableCache ? key : (this.parsingContext.unaliasedKeywordCacheStack[depth] = key);
   }
 
@@ -850,8 +906,18 @@ export class Util {
    * @return {Promise<any>} A promise resolving to the parent key, or another key.
    */
   public async unaliasKeywordParent(keys: any[], depth: number): Promise<any> {
-    // eslint-disable-next-line ts/no-unsafe-return, ts/no-unsafe-argument
-    return await this.unaliasKeyword(depth > 0 && keys[depth - 1], keys, depth - 1);
+    // eslint-disable-next-line ts/no-unsafe-return
+    return this.unaliasKeywordParentFast(keys, depth);
+  }
+
+  /**
+   * Variant of {@link Util#unaliasKeywordParent} that avoids Promise overhead when possible,
+   * analogous to {@link Util#unaliasKeywordFast}.
+   * @see Util#unaliasKeywordParent
+   */
+  public unaliasKeywordParentFast(keys: any[], depth: number): any {
+    // eslint-disable-next-line ts/no-unsafe-argument
+    return this.unaliasKeywordFast(depth > 0 && keys[depth - 1], keys, depth - 1);
   }
 
   /**
@@ -872,7 +938,13 @@ export class Util {
     const newHash: Record<string, any> = {};
     for (const key in hash) {
       // eslint-disable-next-line ts/no-unsafe-assignment
-      newHash[await this.unaliasKeyword(key, keys, depth + 1, true, context)] = hash[key];
+      let unaliasedKey = this.unaliasKeywordFast(key, keys, depth + 1, true, context);
+      if (Util.isPromise(unaliasedKey)) {
+        // eslint-disable-next-line ts/no-unsafe-assignment
+        unaliasedKey = await unaliasedKey;
+      }
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      newHash[unaliasedKey] = hash[key];
     }
     return newHash;
   }
@@ -887,7 +959,47 @@ export class Util {
    * @return {boolean} If we are processing a literal.
    */
   public async isLiteral(keys: any[], depth: number): Promise<boolean> {
+    return this.isLiteralFast(keys, depth);
+  }
+
+  /**
+   * Variant of {@link Util#isLiteral} that avoids Promise overhead when possible:
+   * a boolean is returned directly whenever it can be determined synchronously,
+   * and a Promise is only returned when an asynchronous context lookup is unavoidable.
+   * @see Util#isLiteral
+   */
+  public isLiteralFast(keys: any[], depth: number): boolean | Promise<boolean> {
     for (let i = depth; i >= 0; i--) {
+      // eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-argument
+      const key = this.unaliasKeywordFast(keys[i], keys, i);
+      if (Util.isPromise(key)) {
+        // Continue asynchronously from the current level.
+        return this.isLiteralAsyncFrom(key, keys, i);
+      }
+      if (key === '@annotation') {
+        // Literals may have annotations, which require processing of inner nodes.
+        return false;
+      }
+      if (this.parsingContext.literalStack[i] || this.parsingContext.jsonLiteralStack[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * The asynchronous continuation of {@link Util#isLiteralFast},
+   * starting at level `i` for which the unaliased key promise is given.
+   */
+  private async isLiteralAsyncFrom(pendingKey: Promise<any>, keys: any[], i: number): Promise<boolean> {
+    if (await pendingKey === '@annotation') {
+      // Literals may have annotations, which require processing of inner nodes.
+      return false;
+    }
+    if (this.parsingContext.literalStack[i] || this.parsingContext.jsonLiteralStack[i]) {
+      return true;
+    }
+    for (i--; i >= 0; i--) {
       // eslint-disable-next-line ts/no-unsafe-argument
       if (await this.unaliasKeyword(keys[i], keys, i) === '@annotation') {
         // Literals may have annotations, which require processing of inner nodes.
@@ -909,8 +1021,13 @@ export class Util {
    */
   public async getDepthOffsetGraph(depth: number, keys: any[]): Promise<number> {
     for (let i = depth - 1; i > 0; i--) {
-      // eslint-disable-next-line ts/no-unsafe-argument
-      if (await this.unaliasKeyword(keys[i], keys, i) === '@graph') {
+      // eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-argument
+      let key = this.unaliasKeywordFast(keys[i], keys, i);
+      if (Util.isPromise(key)) {
+        // eslint-disable-next-line ts/no-unsafe-assignment
+        key = await key;
+      }
+      if (key === '@graph') {
         // Skip further processing if we are already in an @graph-@id or @graph-@index container
         const containers = (await EntryHandlerContainer.getContainerHandler(this.parsingContext, keys, i)).containers;
         if (EntryHandlerContainer.isComplexGraphContainer(containers)) {
@@ -956,8 +1073,11 @@ export class Util {
     let graph: RDF.NamedNode | RDF.BlankNode | RDF.DefaultGraph | null = this.getDefaultGraph();
 
     // Check if we are in an @container: @graph.
-    const { containers, depth: depthContainer } = await EntryHandlerContainer
-      .getContainerHandler(this.parsingContext, keys, depth);
+    let containerHandler = EntryHandlerContainer.getContainerHandler(this.parsingContext, keys, depth);
+    if (Util.isPromise(containerHandler)) {
+      containerHandler = await containerHandler;
+    }
+    const { containers, depth: depthContainer } = containerHandler;
     if ('@graph' in containers) {
       // Get the graph from the stack.
       const graphContainerIndex = EntryHandlerContainer.getContainerGraphIndex(containers, depthContainer, keys);
@@ -1008,7 +1128,11 @@ export class Util {
       // Skip array keys
       if (typeof keys[i] !== 'number') {
         // eslint-disable-next-line ts/no-unsafe-argument, ts/no-unsafe-assignment
-        const parentKey = await this.unaliasKeyword(keys[i], keys, i);
+        let parentKey = this.unaliasKeywordFast(keys[i], keys, i);
+        if (Util.isPromise(parentKey)) {
+          // eslint-disable-next-line ts/no-unsafe-assignment
+          parentKey = await parentKey;
+        }
         if (parentKey === '@reverse') {
           return i;
         }

--- a/lib/entryhandler/EntryHandlerArrayValue.ts
+++ b/lib/entryhandler/EntryHandlerArrayValue.ts
@@ -16,23 +16,23 @@ export class EntryHandlerArrayValue implements IEntryHandler<boolean> {
     return true;
   }
 
-  public async validate(
+  public validate(
     parsingContext: ParsingContext,
     util: Util,
     keys: any[],
     depth: number,
     _inProperty: boolean,
-  ): Promise<boolean> {
+  ): boolean {
     return this.test(parsingContext, util, null, keys, depth);
   }
 
-  public async test(
+  public test(
     _parsingContext: ParsingContext,
     _util: Util,
     _key: any,
     keys: any[],
     depth: number,
-  ): Promise<boolean> {
+  ): boolean {
     return typeof keys[depth] === 'number';
   }
 
@@ -45,7 +45,11 @@ export class EntryHandlerArrayValue implements IEntryHandler<boolean> {
     depth: number,
   ): Promise<any> {
     // eslint-disable-next-line ts/no-unsafe-assignment
-    let parentKey = await util.unaliasKeywordParent(keys, depth);
+    let parentKey = util.unaliasKeywordParentFast(keys, depth);
+    if (Util.isPromise(parentKey)) {
+      // eslint-disable-next-line ts/no-unsafe-assignment
+      parentKey = await parentKey;
+    }
 
     // Check if we have an anonymous list
     if (parentKey === '@list') {
@@ -67,7 +71,7 @@ export class EntryHandlerArrayValue implements IEntryHandler<boolean> {
       if (listRootKey !== null) {
         // Emit the given objects as list elements
 
-        const listContext = await parsingContext.getContext(keys);
+        const listContext = parsingContext.tryGetContext(keys) ?? await parsingContext.getContext(keys);
         const values = await util.valueToTerm(listContext, <string> listRootKey, value, depth, <string[]>keys);
         for (const object of values) {
           await this.handleListElement(
@@ -106,13 +110,19 @@ listRootDepth,
       for (let i = depth - 1; i > 0; i--) {
         if (typeof keys[i] !== 'number') {
           // eslint-disable-next-line ts/no-unsafe-assignment
-          parentKey = await util.unaliasKeyword(<string>keys[i], <string[]>keys, i);
+          parentKey = util.unaliasKeywordFast(<string>keys[i], <string[]>keys, i);
+          if (Util.isPromise(parentKey)) {
+            // eslint-disable-next-line ts/no-unsafe-assignment
+            parentKey = await parentKey;
+          }
           break;
         }
       }
 
       // Check if the predicate is marked as an @list in the context
-      const parentContext = await parsingContext.getContext(keys.slice(0, -1));
+      const parentKeysSliced = keys.slice(0, -1);
+      const parentContext = parsingContext.tryGetContext(parentKeysSliced) ??
+        await parsingContext.getContext(parentKeysSliced);
       // eslint-disable-next-line ts/no-unsafe-argument
       if ('@list' in Util.getContextValueContainer(parentContext, parentKey)) {
         // Our value is part of an array

--- a/lib/entryhandler/EntryHandlerContainer.ts
+++ b/lib/entryhandler/EntryHandlerContainer.ts
@@ -1,3 +1,4 @@
+import type { JsonLdContextNormalized } from 'jsonld-context-parser';
 import { ContainerHandlerIdentifier } from '../containerhandler/ContainerHandlerIdentifier';
 import { ContainerHandlerIndex } from '../containerhandler/ContainerHandlerIndex';
 import { ContainerHandlerLanguage } from '../containerhandler/ContainerHandlerLanguage';
@@ -79,11 +80,29 @@ export class EntryHandlerContainer implements IEntryHandler<{
    *          and the `fallback` flag that indicates if the default container type was returned
    *            (i.e., no dedicated container type is defined).
    */
-  public static async getContainerHandler(
+  public static getContainerHandler(
     parsingContext: ParsingContext,
     keys: any[],
     depth: number,
-  ): Promise<{ containers: Record<string, boolean>; depth: number; fallback: boolean }> {
+  ): { containers: Record<string, boolean>; depth: number; fallback: boolean } |
+    Promise<{ containers: Record<string, boolean>; depth: number; fallback: boolean }> {
+    // Determine the context, synchronously if possible, to avoid Promise overhead on a hot path.
+    const contextSync = parsingContext.tryGetContext(keys, 2);
+    if (!contextSync) {
+      return parsingContext.getContext(keys, 2)
+        .then(context => EntryHandlerContainer.getContainerHandlerWithContext(context, keys, depth));
+    }
+    return EntryHandlerContainer.getContainerHandlerWithContext(contextSync, keys, depth);
+  }
+
+  /**
+   * The synchronous tail of {@link EntryHandlerContainer#getContainerHandler}.
+   */
+  private static getContainerHandlerWithContext(
+    context: JsonLdContextNormalized,
+    keys: any[],
+    depth: number,
+  ): { containers: Record<string, boolean>; depth: number; fallback: boolean } {
     const fallback = {
       containers: { '@set': true },
       depth,
@@ -94,7 +113,6 @@ export class EntryHandlerContainer implements IEntryHandler<{
     let checkGraphContainer = false;
 
     // Iterate from deeper to higher
-    const context = await parsingContext.getContext(keys, 2);
     for (let i = depth - 1; i >= 0; i--) {
       // Skip array keys
       if (typeof keys[i] !== 'number') {
@@ -173,9 +191,12 @@ export class EntryHandlerContainer implements IEntryHandler<{
    * @param {number} depth The current depth.
    * @return {Promise<boolean>} If we are in the scope of a container handler.
    */
-  public static async isBufferableContainerHandler(parsingContext: ParsingContext, keys: any[], depth: number):
-  Promise<boolean> {
-    const handler = await EntryHandlerContainer.getContainerHandler(parsingContext, keys, depth);
+  public static isBufferableContainerHandler(parsingContext: ParsingContext, keys: any[], depth: number):
+  boolean | Promise<boolean> {
+    const handler = EntryHandlerContainer.getContainerHandler(parsingContext, keys, depth);
+    if (Util.isPromise(handler)) {
+      return handler.then(handlerValue => !handlerValue.fallback && !('@graph' in handlerValue.containers));
+    }
     return !handler.fallback && !('@graph' in handler.containers);
   }
 
@@ -187,24 +208,46 @@ export class EntryHandlerContainer implements IEntryHandler<{
     return true;
   }
 
-  public async validate(
+  public validate(
     parsingContext: ParsingContext,
     util: Util,
     keys: any[],
     depth: number,
     _inProperty: boolean,
-  ): Promise<boolean> {
-    return Boolean(await this.test(parsingContext, util, null, keys, depth));
+  ): boolean | Promise<boolean> {
+    const testResult = this.test(parsingContext, util, null, keys, depth);
+    if (Util.isPromise(testResult)) {
+      return testResult.then(Boolean);
+    }
+    return Boolean(testResult);
   }
 
-  public async test(
+  public test(
     parsingContext: ParsingContext,
     _util: Util,
     _key: any,
     keys: any[],
     depth: number,
-  ): Promise<{ containers: Record<string, boolean>; handler: IContainerHandler } | null> {
-    const containers = Util.getContextValueContainer(await parsingContext.getContext(keys, 2), <string>keys[depth - 1]);
+  ): { containers: Record<string, boolean>; handler: IContainerHandler } | null |
+    Promise<{ containers: Record<string, boolean>; handler: IContainerHandler } | null> {
+    // Determine the context, synchronously if possible, to avoid Promise overhead on a hot path.
+    const contextSync = parsingContext.tryGetContext(keys, 2);
+    if (!contextSync) {
+      return parsingContext.getContext(keys, 2)
+        .then(context => EntryHandlerContainer.testWithContext(context, keys, depth));
+    }
+    return EntryHandlerContainer.testWithContext(contextSync, keys, depth);
+  }
+
+  /**
+   * The synchronous tail of {@link EntryHandlerContainer#test}.
+   */
+  private static testWithContext(
+    context: JsonLdContextNormalized,
+    keys: any[],
+    depth: number,
+  ): { containers: Record<string, boolean>; handler: IContainerHandler } | null {
+    const containers = Util.getContextValueContainer(context, <string>keys[depth - 1]);
     for (const containerName in EntryHandlerContainer.CONTAINER_HANDLERS) {
       if (containers[containerName]) {
         return {

--- a/lib/entryhandler/EntryHandlerInvalidFallback.ts
+++ b/lib/entryhandler/EntryHandlerInvalidFallback.ts
@@ -15,23 +15,23 @@ export class EntryHandlerInvalidFallback implements IEntryHandler<boolean> {
     return true;
   }
 
-  public async validate(
+  public validate(
     _parsingContext: ParsingContext,
     _util: Util,
     _keys: any[],
     _depth: number,
     _inProperty: boolean,
-  ): Promise<boolean> {
+  ): boolean {
     return false;
   }
 
-  public async test(
+  public test(
     _parsingContext: ParsingContext,
     _util: Util,
     _key: any,
     _keys: any[],
     _depth: number,
-  ): Promise<boolean> {
+  ): boolean {
     return true;
   }
 

--- a/lib/entryhandler/EntryHandlerPredicate.ts
+++ b/lib/entryhandler/EntryHandlerPredicate.ts
@@ -1,4 +1,5 @@
 import type * as RDF from '@rdfjs/types';
+import type { JsonLdContextNormalized } from 'jsonld-context-parser';
 import { ERROR_CODES, ErrorCoded } from 'jsonld-context-parser';
 import type { AnnotationsBufferEntry, ParsingContext } from '../ParsingContext';
 import { Util } from '../Util';
@@ -35,7 +36,7 @@ export class EntryHandlerPredicate implements IEntryHandler<boolean> {
     isAnnotation: boolean,
   ): Promise<void> {
     const depthProperties: number = await util.getPropertiesDepth(keys, depth);
-    const depthOffsetGraph = await util.getDepthOffsetGraph(depth, keys);
+    const depthOffsetGraph: number = await util.getDepthOffsetGraph(depth, keys);
     const depthPropertiesGraph: number = depth - depthOffsetGraph;
 
     const subjects = parsingContext.idStack[depthProperties];
@@ -128,38 +129,54 @@ export class EntryHandlerPredicate implements IEntryHandler<boolean> {
     return true;
   }
 
-  public async validate(
+  public validate(
     parsingContext: ParsingContext,
     util: Util,
     keys: any[],
     depth: number,
     _inProperty: boolean,
-  ): Promise<boolean> {
+  ): boolean | Promise<boolean> {
     // eslint-disable-next-line ts/no-unsafe-assignment
     const key = keys[depth];
     if (key) {
-      const context = await parsingContext.getContext(keys);
-
-      // eslint-disable-next-line ts/await-thenable
-      if (!parsingContext.jsonLiteralStack[depth] && await util.predicateToTerm(context, <string>keys[depth])) {
-        // If this valid predicate is of type @json, mark it so in the stack so that no deeper handling of nodes occurs.
-
-        if (Util.getContextValueType(context, <string>key) === '@json') {
-          parsingContext.jsonLiteralStack[depth + 1] = true;
-        }
-        return true;
+      const contextSync = parsingContext.tryGetContext(keys);
+      if (!contextSync) {
+        return parsingContext.getContext(keys)
+          .then(context => EntryHandlerPredicate.validateWithContext(parsingContext, util, context, keys, depth));
       }
+      return EntryHandlerPredicate.validateWithContext(parsingContext, util, contextSync, keys, depth);
     }
     return false;
   }
 
-  public async test(
+  /**
+   * The synchronous tail of {@link EntryHandlerPredicate#validate}.
+   */
+  private static validateWithContext(
+    parsingContext: ParsingContext,
+    util: Util,
+    context: JsonLdContextNormalized,
+    keys: any[],
+    depth: number,
+  ): boolean {
+    if (!parsingContext.jsonLiteralStack[depth] && util.predicateToTerm(context, <string>keys[depth])) {
+      // If this valid predicate is of type @json, mark it so in the stack so that no deeper handling of nodes occurs.
+
+      if (Util.getContextValueType(context, <string>keys[depth]) === '@json') {
+        parsingContext.jsonLiteralStack[depth + 1] = true;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  public test(
     _parsingContext: ParsingContext,
     _util: Util,
     _key: any,
     keys: any[],
     depth: number,
-  ): Promise<boolean> {
+  ): boolean {
     // eslint-disable-next-line ts/no-unsafe-return
     return keys[depth];
   }
@@ -175,17 +192,20 @@ export class EntryHandlerPredicate implements IEntryHandler<boolean> {
   ): Promise<any> {
     // eslint-disable-next-line ts/no-unsafe-assignment
     const keyOriginal = keys[depth];
-    const context = await parsingContext.getContext(keys);
+    const context = parsingContext.tryGetContext(keys) ?? await parsingContext.getContext(keys);
 
-    // eslint-disable-next-line ts/await-thenable
-    const predicate = await util.predicateToTerm(context, <string>key);
+    const predicate = util.predicateToTerm(context, <string>key);
     if (predicate) {
       const objects = await util.valueToTerm(context, <string>key, value, depth, <string[]>keys);
       if (objects.length > 0) {
         for (let object of objects) {
           // Based on parent key, check if reverse, embedded, and annotation.
           // eslint-disable-next-line ts/no-unsafe-assignment
-          let parentKey = await util.unaliasKeywordParent(<string[]>keys, depth);
+          let parentKey = util.unaliasKeywordParentFast(<string[]>keys, depth);
+          if (Util.isPromise(parentKey)) {
+            // eslint-disable-next-line ts/no-unsafe-assignment
+            parentKey = await parentKey;
+          }
 
           const reverse = Util.isPropertyReverse(context, <string>keyOriginal, <string>parentKey);
           let parentDepthOffset = 0;
@@ -197,7 +217,11 @@ export class EntryHandlerPredicate implements IEntryHandler<boolean> {
               depth--;
             }
             // eslint-disable-next-line ts/no-unsafe-assignment
-            parentKey = await util.unaliasKeywordParent(<string[]>keys, depth - parentDepthOffset);
+            parentKey = util.unaliasKeywordParentFast(<string[]>keys, depth - parentDepthOffset);
+            if (Util.isPromise(parentKey)) {
+              // eslint-disable-next-line ts/no-unsafe-assignment
+              parentKey = await parentKey;
+            }
           }
 
           const isEmbedded = Util.isPropertyInEmbeddedNode(<string>parentKey);

--- a/lib/entryhandler/IEntryHandler.ts
+++ b/lib/entryhandler/IEntryHandler.ts
@@ -27,7 +27,11 @@ export interface IEntryHandler<T> {
    * @param {any[]} keys A stack of keys.
    * @param {number} depth The current depth.
    * @param {boolean} inProperty If the current depth is part of a valid property node.
-   * @return {Promise<boolean>} A promise resolving to a boolean representing if the key is valid.
+   * @return {boolean | Promise<boolean>} A boolean representing if the key is valid,
+   *                                      possibly wrapped in a promise.
+   *                                      Implementations SHOULD return the boolean directly
+   *                                      when it can be determined synchronously,
+   *                                      as this avoids Promise overhead on a hot path.
    */
   validate: (
     parsingContext: ParsingContext,
@@ -35,7 +39,7 @@ export interface IEntryHandler<T> {
     keys: any[],
     depth: number,
     inProperty: boolean,
-  ) => Promise<boolean>;
+  ) => boolean | Promise<boolean>;
 
   /**
    * Check if this handler can handle the given key.
@@ -45,10 +49,20 @@ export interface IEntryHandler<T> {
    * @param key The current (unaliased) key.
    * @param {any[]} keys A stack of keys.
    * @param {number} depth The current depth.
-   * @return {Promise<T | null>} A promise resolving to a truthy value if it can handle.
+   * @return {T | null | Promise<T | null>} A truthy value if it can handle, possibly wrapped
+   *                             in a promise.
    *                             (this value will be passed into {@link IEntryHandler#handle})
+   *                             Implementations SHOULD return the value directly
+   *                             when it can be determined synchronously,
+   *                             as this avoids Promise overhead on a hot path.
    */
-  test: (parsingContext: ParsingContext, util: Util, key: any, keys: any[], depth: number) => Promise<T | null>;
+  test: (
+    parsingContext: ParsingContext,
+    util: Util,
+    key: any,
+    keys: any[],
+    depth: number,
+  ) => T | null | Promise<T | null>;
 
   /**
    * Handle the given entry.

--- a/lib/entryhandler/keyword/EntryHandlerKeyword.ts
+++ b/lib/entryhandler/keyword/EntryHandlerKeyword.ts
@@ -20,23 +20,23 @@ export abstract class EntryHandlerKeyword implements IEntryHandler<boolean> {
     return true;
   }
 
-  public async validate(
+  public validate(
     _parsingContext: ParsingContext,
     _util: Util,
     _keys: any[],
     _depth: number,
     _inProperty: boolean,
-  ): Promise<boolean> {
+  ): boolean | Promise<boolean> {
     return false;
   }
 
-  public async test(
+  public test(
     _parsingContext: ParsingContext,
     _util: Util,
     key: any,
     _keys: any[],
     _depth: number,
-  ): Promise<boolean> {
+  ): boolean | Promise<boolean> {
     return key === this.keyword;
   }
 

--- a/lib/entryhandler/keyword/EntryHandlerKeywordUnknownFallback.ts
+++ b/lib/entryhandler/keyword/EntryHandlerKeywordUnknownFallback.ts
@@ -1,6 +1,6 @@
 import { ERROR_CODES, ErrorCoded, Util as ContextUtil } from 'jsonld-context-parser';
 import type { ParsingContext } from '../../ParsingContext';
-import type { Util } from '../../Util';
+import { Util } from '../../Util';
 import type { IEntryHandler } from '../IEntryHandler';
 
 /**
@@ -24,15 +24,26 @@ export class EntryHandlerKeywordUnknownFallback implements IEntryHandler<boolean
     return true;
   }
 
-  public async validate(
+  public validate(
     parsingContext: ParsingContext,
     util: Util,
     keys: any[],
     depth: number,
     inProperty: boolean,
-  ): Promise<boolean> {
+  ): boolean | Promise<boolean> {
     // eslint-disable-next-line ts/no-unsafe-assignment
-    const key = await util.unaliasKeyword(<string>keys[depth], <string[]>keys, depth);
+    const key = util.unaliasKeywordFast(<string>keys[depth], <string[]>keys, depth);
+    if (Util.isPromise(key)) {
+      return key.then(resolvedKey =>
+        EntryHandlerKeywordUnknownFallback.validateWithKey(<string>resolvedKey, inProperty));
+    }
+    return EntryHandlerKeywordUnknownFallback.validateWithKey(<string>key, inProperty);
+  }
+
+  /**
+   * The synchronous tail of {@link EntryHandlerKeywordUnknownFallback#validate}.
+   */
+  private static validateWithKey(key: string, inProperty: boolean): boolean {
     if (ContextUtil.isPotentialKeyword(key)) {
       // Don't emit anything inside free-floating lists
       if (!inProperty && key === '@list') {
@@ -44,13 +55,13 @@ export class EntryHandlerKeywordUnknownFallback implements IEntryHandler<boolean
     return false;
   }
 
-  public async test(
+  public test(
     _parsingContext: ParsingContext,
     _util: Util,
     key: any,
     _keys: any[],
     _depth: number,
-  ): Promise<boolean> {
+  ): boolean {
     return ContextUtil.isPotentialKeyword(key);
   }
 

--- a/lib/entryhandler/keyword/EntryHandlerKeywordValue.ts
+++ b/lib/entryhandler/keyword/EntryHandlerKeywordValue.ts
@@ -1,5 +1,5 @@
 import type { ParsingContext } from '../../ParsingContext';
-import type { Util } from '../../Util';
+import { Util } from '../../Util';
 import { EntryHandlerKeyword } from './EntryHandlerKeyword';
 
 /**
@@ -10,31 +10,47 @@ export class EntryHandlerKeywordValue extends EntryHandlerKeyword {
     super('@value');
   }
 
-  public async validate(
+  public validate(
     parsingContext: ParsingContext,
     util: Util,
     keys: any[],
     depth: number,
     inProperty: boolean,
-  ): Promise<boolean> {
+  ): boolean | Promise<boolean> {
     // If this is @value, mark it so in the stack so that no deeper handling of nodes occurs.
     // eslint-disable-next-line ts/no-unsafe-assignment
     const key = keys[depth];
-    if (key && !parsingContext.literalStack[depth] && await this.test(parsingContext, util, key, keys, depth)) {
-      parsingContext.literalStack[depth] = true;
+    if (key && !parsingContext.literalStack[depth]) {
+      const testResult = this.test(parsingContext, util, key, keys, depth);
+      if (Util.isPromise(testResult)) {
+        return testResult.then((testResultValue) => {
+          if (testResultValue) {
+            parsingContext.literalStack[depth] = true;
+          }
+          return super.validate(parsingContext, util, keys, depth, inProperty);
+        });
+      }
+      if (testResult) {
+        parsingContext.literalStack[depth] = true;
+      }
     }
 
     return super.validate(parsingContext, util, keys, depth, inProperty);
   }
 
-  public async test(
+  public test(
     parsingContext: ParsingContext,
     util: Util,
     _key: any,
     keys: any[],
     depth: number,
-  ): Promise<boolean> {
-    return await util.unaliasKeyword(<string>keys[depth], <string[]>keys.slice(0, -1), depth - 1, true) === '@value';
+  ): boolean | Promise<boolean> {
+    // eslint-disable-next-line ts/no-unsafe-assignment
+    const unaliased = util.unaliasKeywordFast(<string>keys[depth], <string[]>keys.slice(0, -1), depth - 1, true);
+    if (Util.isPromise(unaliased)) {
+      return unaliased.then(unaliasedValue => unaliasedValue === '@value');
+    }
+    return unaliased === '@value';
   }
 
   public async handle(

--- a/test/JsonLdParser-test.ts
+++ b/test/JsonLdParser-test.ts
@@ -140,16 +140,12 @@ describe('JsonLdParser', () => {
         .toThrow(new ErrorCoded(`Missing context link header for media type text/turtle+json on BASE`, ERROR_CODES.LOADING_DOCUMENT_FAILED));
     });
 
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line max-len
     it('should handle a plain JSON response without link header when ignoreMissingContextLinkHeader is true', () => {
       // eslint-disable-next-line max-len
       const parser = JsonLdParser.fromHttpResponse('BASE', 'application/json', undefined, { ignoreMissingContextLinkHeader: true });
       expect((<any> parser).options.baseIRI).toBe('BASE');
     });
 
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line max-len
     it('should handle a JSON extension type without link header when ignoreMissingContextLinkHeader is true', () => {
       // eslint-disable-next-line max-len
       const parser = JsonLdParser.fromHttpResponse('BASE', 'text/turtle+json', undefined, { ignoreMissingContextLinkHeader: true });
@@ -252,8 +248,6 @@ describe('JsonLdParser', () => {
       expect(parser.util.dataFactory).toBeTruthy();
     });
 
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line max-len
     it('should have a default root context', async() => {
       // eslint-disable-next-line max-len
       await expect(parser.parsingContext.rootContext).resolves.toEqual(new JsonLdContextNormalized({ '@base': undefined }));
@@ -1702,8 +1696,7 @@ describe('JsonLdParser', () => {
   "term": {"@list": ["http://example/bar"]}
 }`);
           parser = new JsonLdParser({ dataFactory: DF, streamingProfile, allowSubjectList: false });
-          // eslint-disable-next-line max-len
-          // eslint-disable-next-line max-len
+
           await expect(arrayifyStream(stream.pipe(parser))).rejects
             // eslint-disable-next-line max-len
             .toThrow(new ErrorCoded('Found illegal list value in subject position at term', ERROR_CODES.INVALID_REVERSE_PROPERTY_VALUE));
@@ -5738,8 +5731,7 @@ describe('JsonLdParser', () => {
   "pred1": "http://ex.org/obj1",
   "@type": "Foo"
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'type-scoped context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5843,8 +5835,7 @@ describe('JsonLdParser', () => {
   },
   "@type": "Foo"
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5862,8 +5853,7 @@ describe('JsonLdParser', () => {
   },
   "@type": "Foo"
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5884,8 +5874,7 @@ describe('JsonLdParser', () => {
     }
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5903,8 +5892,7 @@ describe('JsonLdParser', () => {
     }
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'type-scoped context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5925,8 +5913,7 @@ describe('JsonLdParser', () => {
     }
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5944,8 +5931,7 @@ describe('JsonLdParser', () => {
     }
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5966,8 +5952,7 @@ describe('JsonLdParser', () => {
   },
   "pred1": "http://ex.org/obj1"
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -5985,8 +5970,7 @@ describe('JsonLdParser', () => {
   },
   "pred1": "http://ex.org/obj1"
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -6011,8 +5995,7 @@ describe('JsonLdParser', () => {
     "@type": "Type"
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(new ErrorCoded('Found an out-of-order ' +
               // eslint-disable-next-line max-len
               'type-scoped context, while streaming is enabled.(disable `streamingProfile`)', ERROR_CODES.INVALID_STREAMING_KEY_ORDER));
@@ -6581,8 +6564,7 @@ describe('JsonLdParser', () => {
   "@id": "http://ex.org/myid",
   "a": "http://ex.org/bla",
 }`);
-          // eslint-disable-next-line max-len
-          // eslint-disable-next-line max-len
+
           await expect(arrayifyStream(stream.pipe(parser))).rejects
             // eslint-disable-next-line max-len
             .toThrow(new ErrorCoded('Invalid @reverse value, must be absolute IRI or blank node: \'@type\'', ERROR_CODES.INVALID_IRI_MAPPING));
@@ -7602,8 +7584,7 @@ describe('JsonLdParser', () => {
     }
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(
               // eslint-disable-next-line max-len
               new ErrorCoded('Keywords can not be used as @index value, got: @keyword', ERROR_CODES.INVALID_TERM_DEFINITION),
@@ -7711,8 +7692,7 @@ describe('JsonLdParser', () => {
     "Value1": "ex:id1"
   }
 }`);
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line max-len
+
             await expect(arrayifyStream(stream.pipe(parser))).rejects.toThrow(
               // eslint-disable-next-line max-len
               new ErrorCoded('A context @type must be an absolute IRI, found: \'p\': \'@bla\'', ERROR_CODES.INVALID_TYPE_MAPPING),
@@ -12164,8 +12144,7 @@ describe('JsonLdParser', () => {
   "@id": "http://example/foo",
   "term": {"@list": ["http://example/bar"]}
 }`);
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line max-len
+
         await expect(arrayifyStream(stream.pipe(parser))).rejects
           // eslint-disable-next-line max-len
           .toThrow(new ErrorCoded('Found illegal list value in subject position at term', ERROR_CODES.INVALID_REVERSE_PROPERTY_VALUE));
@@ -12179,8 +12158,7 @@ describe('JsonLdParser', () => {
   "@id": "http://example/foo",
   "term": {"@list": "http://example/bar"}
 }`);
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line max-len
+
         await expect(arrayifyStream(stream.pipe(parser))).rejects
           // eslint-disable-next-line max-len
           .toThrow(new ErrorCoded('Found illegal list value in subject position at term', ERROR_CODES.INVALID_REVERSE_PROPERTY_VALUE));
@@ -12194,8 +12172,7 @@ describe('JsonLdParser', () => {
   "@id": "http://example/foo",
   "term": {"@list": []}
 }`);
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line max-len
+
         await expect(arrayifyStream(stream.pipe(parser))).rejects
           // eslint-disable-next-line max-len
           .toThrow(new ErrorCoded('Found illegal list value in subject position at term', ERROR_CODES.INVALID_REVERSE_PROPERTY_VALUE));
@@ -12242,8 +12219,7 @@ describe('JsonLdParser', () => {
 {
   "@included": { "@value": "bla" }
 }`);
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line max-len
+
         await expect(arrayifyStream(stream.pipe(parser))).rejects
           // eslint-disable-next-line max-len
           .toThrow(new ErrorCoded('Found an illegal @included @value node \'{"@value":"bla"}\'', ERROR_CODES.INVALID_INCLUDED_VALUE));
@@ -12254,8 +12230,7 @@ describe('JsonLdParser', () => {
 {
   "@included": { "@list": [ "bla" ] }
 }`);
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line max-len
+
         await expect(arrayifyStream(stream.pipe(parser))).rejects
           // eslint-disable-next-line max-len
           .toThrow(new ErrorCoded('Found an illegal @included @list node \'{"@list":["bla"]}\'', ERROR_CODES.INVALID_INCLUDED_VALUE));
@@ -12353,8 +12328,7 @@ describe('JsonLdParser', () => {
     "http://xmlns.com/foaf/0.1/knows": "Name"
   }
 }`);
-      // eslint-disable-next-line max-len
-      // eslint-disable-next-line max-len
+
       await expect(arrayifyStream(stream.pipe(parser))).rejects
         // eslint-disable-next-line max-len
         .toEqual(new ErrorCoded('Found illegal literal in subject position: Name', ERROR_CODES.INVALID_REVERSE_PROPERTY_VALUE));

--- a/test/entryhandler/EntryHandlerContainer-test.ts
+++ b/test/entryhandler/EntryHandlerContainer-test.ts
@@ -125,7 +125,9 @@ describe('EntryHandlerContainer', () => {
 
   describe('getContainerHandler', () => {
     it('should return fallback on an empty array', async() => {
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [], 0)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [], 0),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 0,
@@ -134,7 +136,9 @@ describe('EntryHandlerContainer', () => {
     });
 
     it('should return fallback on one number', async() => {
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 0 ], 0)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 0 ], 0),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 0,
@@ -143,7 +147,9 @@ describe('EntryHandlerContainer', () => {
     });
 
     it('should return fallback on all numbers', async() => {
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 0, 1, 2 ], 2)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 0, 1, 2 ], 2),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 2,
@@ -154,8 +160,10 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toMatchObject({
           containers: { '@id': true },
           depth: 2,
@@ -166,8 +174,10 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth in an @index container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@index': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toMatchObject({
           containers: { '@index': true },
           depth: 2,
@@ -178,8 +188,10 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth in an @language container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@language': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toMatchObject({
           containers: { '@language': true },
           depth: 2,
@@ -190,8 +202,10 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth in an @type container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@type': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toMatchObject({
           containers: { '@type': true },
           depth: 2,
@@ -202,8 +216,10 @@ describe('EntryHandlerContainer', () => {
     it('should return fallback when targeting a depth in an unknown container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@bla': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 3,
@@ -214,8 +230,10 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth within one array in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 0, 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 0, 'subSubKey' ], 4),
+      )).resolves
         .toMatchObject({
           containers: { '@id': true },
           depth: 2,
@@ -226,8 +244,10 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth within two arrays in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 0, 1, 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 0, 1, 'subSubKey' ], 4),
+      )).resolves
         .toMatchObject({
           containers: { '@id': true },
           depth: 2,
@@ -238,8 +258,14 @@ describe('EntryHandlerContainer', () => {
     it('should return fallback when targeting a depth within an object in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 4,
@@ -250,7 +276,9 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth in an @graph container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true }}})));
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key' ], 2)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key' ], 2),
+      )).resolves
         .toMatchObject({
           containers: { '@graph': true },
           depth: 2,
@@ -262,7 +290,9 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@set': true }}},
       )));
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key' ], 2)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key' ], 2),
+      )).resolves
         .toMatchObject({
           containers: { '@graph': true, '@set': true },
           depth: 2,
@@ -273,7 +303,9 @@ describe('EntryHandlerContainer', () => {
     it('should return fallback when targeting a depth above an @graph container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true }}})));
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key' ], 1)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key' ], 1),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 1,
@@ -284,8 +316,10 @@ describe('EntryHandlerContainer', () => {
     it('should return fallback when targeting a depth below an @graph container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'keyDeeper' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'keyDeeper' ], 3),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 3,
@@ -297,8 +331,14 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@index': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@graph': true, '@index': true },
           depth: 2,
@@ -309,8 +349,14 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth within a graph id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true, '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@graph': true, '@id': true },
           depth: 2,
@@ -322,8 +368,14 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@index': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          3,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@graph': true, '@index': true },
           depth: 2,
@@ -334,8 +386,14 @@ describe('EntryHandlerContainer', () => {
     it('should return when targeting a depth of a graph id container in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true, '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          3,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@graph': true, '@id': true },
           depth: 2,
@@ -347,8 +405,14 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@type': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          3,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 3,
@@ -360,8 +424,14 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@language': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          3,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 3,
@@ -373,8 +443,14 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@index': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ], 5)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ],
+          5,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 5,
@@ -385,8 +461,14 @@ describe('EntryHandlerContainer', () => {
     it('should return fallback when targeting a depth below a graph id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true, '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.getContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ], 5)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.getContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ],
+          5,
+        ),
+      )).resolves
         .toMatchObject({
           containers: { '@set': true },
           depth: 5,
@@ -397,97 +479,135 @@ describe('EntryHandlerContainer', () => {
 
   describe('isBufferableContainerHandler', () => {
     it('should return false on an empty array', async() => {
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [], 0)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [], 0),
+      )).resolves
         .toBe(false);
     });
 
     it('should return false on one number', async() => {
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 0 ], 0)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 0 ], 0),
+      )).resolves
         .toBe(false);
     });
 
     it('should return false on all numbers', async() => {
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 0, 1, 2 ], 2)).resolves
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 0, 1, 2 ], 2),
+      )).resolves
         .toBe(false);
     });
 
     it('should return true when targeting a depth in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toBe(true);
     });
 
     it('should return true when targeting a depth in an @index container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@index': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toBe(true);
     });
 
     it('should return true when targeting a depth in an @language container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@language': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toBe(true);
     });
 
     it('should return true when targeting a depth in an @type container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@type': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toBe(true);
     });
 
     it('should return true when targeting a depth in an unknown container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@bla': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toBe(false);
     });
 
     it('should return true when targeting a depth within one array in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 0, 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 0, 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toBe(true);
     });
 
     it('should return true when targeting a depth within two arrays in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 0, 1, 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 0, 1, 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toBe(true);
     });
 
     it('should return false when targeting a depth within an object in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toBe(false);
     });
 
     it('should return false when targeting a depth in an @graph container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 2)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 2),
+      )).resolves
         .toBe(false);
     });
 
     it('should return true when targeting a depth below an @graph container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey' ], 3),
+      )).resolves
         .toBe(false);
     });
 
@@ -495,16 +615,28 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@index': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toBe(false);
     });
 
     it('should return false when targeting a depth within a graph id container in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true, '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 4)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          4,
+        ),
+      )).resolves
         .toBe(false);
     });
 
@@ -512,16 +644,28 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@index': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          3,
+        ),
+      )).resolves
         .toBe(false);
     });
 
     it('should return false when targeting a depth of a graph id container in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true, '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey' ], 3)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey' ],
+          3,
+        ),
+      )).resolves
         .toBe(false);
     });
 
@@ -529,16 +673,28 @@ describe('EntryHandlerContainer', () => {
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized(
         { container: { '@container': { '@graph': true, '@index': true }}},
       )));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ], 5)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ],
+          5,
+        ),
+      )).resolves
         .toBe(false);
     });
 
     it('should return false when targeting a depth below a graph id container in an @id container', async() => {
       // eslint-disable-next-line max-len
       parsingContext.contextTree.setContext([ 'a', 'container' ], Promise.resolve(new JsonLdContextNormalized({ container: { '@container': { '@graph': true, '@id': true }}})));
-      // eslint-disable-next-line max-len
-      await expect(EntryHandlerContainer.isBufferableContainerHandler(parsingContext, [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ], 5)).resolves
+
+      await expect(Promise.resolve(
+        EntryHandlerContainer.isBufferableContainerHandler(
+          parsingContext,
+          [ 'a', 'container', 'key', 'subKey', 'subSubKey', 'subSubSubKey' ],
+          5,
+        ),
+      )).resolves
         .toBe(false);
     });
   });

--- a/test/entryhandler/EntryHandlerPredicate-test.ts
+++ b/test/entryhandler/EntryHandlerPredicate-test.ts
@@ -22,25 +22,27 @@ describe('EntryHandlerPredicate', () => {
 
   describe('validate', () => {
     it('should return false for empty keys', async() => {
-      await expect(handler.validate(parsingContext, util, [ '' ], 0, false)).resolves.toBeFalsy();
+      await expect(Promise.resolve(handler.validate(parsingContext, util, [ '' ], 0, false))).resolves.toBeFalsy();
     });
 
     it('should return false on blank node properties', async() => {
-      await expect(handler.validate(parsingContext, util, [ '_:b' ], 0, false)).resolves.toBeFalsy();
+      await expect(Promise.resolve(handler.validate(parsingContext, util, [ '_:b' ], 0, false))).resolves.toBeFalsy();
     });
 
     it('should return true on regular properties', async() => {
-      await expect(handler.validate(parsingContext, util, [ 'http://prop.com' ], 0, false)).resolves.toBeTruthy();
+      await expect(Promise.resolve(handler.validate(parsingContext, util, [ 'http://prop.com' ], 0, false))).resolves.toBeTruthy();
     });
 
     it('should return true on compacted properties', async() => {
       parsingContext.contextTree.setContext([], Promise.resolve(new JsonLdContextNormalized({ prop: 'http://example.org/' })));
-      await expect(handler.validate(parsingContext, util, [ 'prop' ], 0, false)).resolves.toBeTruthy();
+      await expect(Promise.resolve(handler.validate(parsingContext, util, [ 'prop' ], 0, false))).resolves.toBeTruthy();
     });
 
     it('should return false on compacted properties without known expansion', async() => {
       parsingContext.contextTree.setContext([], Promise.resolve(new JsonLdContextNormalized({ prop: 'http://example.org/' })));
-      await expect(handler.validate(parsingContext, util, [ 'propDifferent' ], 0, false)).resolves.toBeFalsy();
+      await expect(Promise.resolve(
+        handler.validate(parsingContext, util, [ 'propDifferent' ], 0, false),
+      )).resolves.toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Structural, API-preserving performance work on the JSON-LD streaming hot path. All figures are **parser-level** (time to parse documents to quads); no end-to-end claims.

## Results

Corpus: 90 real CommunitySolidServer `dist/components/**/*.jsonld` component documents (226 KB, 2,687 quads emitted per iteration), parsed with a fresh `JsonLdParser` per document (`streamingProfile: false`, `skipContextValidation: true`, `strictValues: true`, prefetched-document-loader-style context loading) — the shape Components.js/CSS boot produces. **Quad counts are identical across all variants on every run.**

**Workload 1 — shared-context workload** (`ContextParser.parse` memoized across documents, simulating a shared context parser + normalized-context cache, cf. rubensworks/jsonld-context-parser.js#85 and rubensworks/jsonld-streaming-parser.js#151; this isolates the streaming parser's own cost):

| Variant | min ms / 90 docs | median ms / 90 docs | vs stock |
|---|---:|---:|---|
| stock `master` (5aae884) | 104.22 | 122.05 | — |
| + Tier-1 micro-opts (= upstream #150) | 98.16 | 112.95 | 1.06x / 1.08x |
| + **this branch (structural)** | **56.21** | **69.61** | **1.85x / 1.75x** |

This branch vs Tier-1 alone: 1.75x (min) / 1.62x (median).

**Workload 2 — stock-shaped, no context cache** (every document re-normalizes the ~2,100-term CSS + componentsjs contexts):

| Variant | min ms / 90 docs | median ms / 90 docs | vs stock |
|---|---:|---:|---|
| stock `master` | 425.82 | 459.51 | — |
| + Tier-1 | 428.55 | 458.46 | ~1.0x (noise) |
| + **this branch** | **383.51** | **413.59** | **1.11x** |

Context re-normalization dominates workload 2; that cost is addressed separately by jsonld-context-parser#85. Stacking both: stock uncached median 459.51 ms vs cached + this branch 69.61 ms is **~6.6x on this workload for the combined stack** (the benchmark memoization approximates the #85 cache without its key-derivation overhead, so treat ~6.6x as an upper bound for the stack, not a claim for this PR alone).

## Methodology

- Interleaved A/B/C process runs (stock, Tier-1, structural; 5 reps x 25 iterations for workload 1, 3 reps x 8 iterations for workload 2), medians and minima reported across reps. Warmup iterations excluded.
- Environment: Node v22.23.1, Linux x86_64, 2-core shared box under `nice -n 18` (hence interleaving; minima are the least noisy statistic here).
- Version pins: base commit 5aae884 (post-3.2.1 master); jsonld-context-parser 3.0.1; @bergos/jsonparse 1.4.2; rdf-data-factory 2.0.2; readable-stream 4.7.0.

## Profile evidence (`node --cpu-prof`, workload 1)

Before (Tier-1 build): `runMicrotasks` 15.6% + GC 12.6% of self-time; `ParsingContext.getContext` 7.2% + `getContextPropagationAware` 5.6% + `ContextTree.getContext` 2.5%; 13 awaited `async` handler `test()` calls per emitted value.

After this branch: `runMicrotasks` 5.7%, context-lookup family ~2.3% combined; the remaining top costs are the JSON tokenizer (`@bergos/jsonparse` ~6.4%), GC (~12.6%), and term/IRI construction — i.e. the Promise/microtask machinery no longer dominates, which is why the ceiling is where it is.

## What changed (2 commits)

1. **aca3d9d — Tier-1 micro-optimizations.** Identical content to upstream draft rubensworks/jsonld-streaming-parser.js#150 (`ContextTree.getContext` index parameter, no-op wrapper elision in `ParsingContext.getContext`, synchronous `hasContext` presence check, single-allocation `keys` build). Included so this PR is self-contained and independently benchmarkable; if #150 lands first, this branch rebases onto it trivially.
2. **4adf9c5 — structural Promise-churn elimination:**
   - `ContextTree` caches resolved context values next to their promises and walks the tree iteratively (zero-allocation `lookup`), instead of allocating a Promise + closure per tree level per lookup.
   - `ParsingContext` gains a synchronous context fast path (`tryGetContext` / `tryGetContextPropagationAware`) mirroring the async logic for the common case (resolved context, no property-scoped contexts, no propagation special cases), falling back to the unchanged async path otherwise. Trailing array-index trimming and offsets use an index bound instead of two `keys.slice()` allocations per lookup.
   - `IEntryHandler.test/validate` may return results directly; the dispatch loops only `await` actual Promises. All entry handlers now return synchronously when possible — removing up to 13 awaited microtasks per emitted value.
   - Same maybe-synchronous treatment for `Util.unaliasKeyword(Parent)/isLiteral/getPropertiesDepth/unaliasKeywords` and `EntryHandlerContainer.getContainerHandler/isBufferableContainerHandler`.
   - The value job chain starts jobs inline when the chain is idle instead of unconditionally deferring each job to a later microtask; job ordering, error skipping and error reporting are preserved.

## Behavior / contract notes (for review)

- **No public API removed or changed incompatibly.** `IEntryHandler.test/validate` return types are widened to `T | Promise<T>` (implementations returning Promises stay valid; this is TS-visible, semver-minor). `EntryHandlerContainer.getContainerHandler/isBufferableContainerHandler` may return synchronously (all `await`-based callers unaffected). `ContextTree.setContext` additionally accepts an already-resolved context.
- Jobs may now start inline within `jsonParser.write()` when the chain is idle, so quads can be emitted a few microtasks earlier relative to `write()` returning. Sequencing, backpressure handling, and error propagation are unchanged; a rejected job still skips all later chained jobs.
- Tests: **1617/1617 green** (10 suites, includes the JSON-LD streaming spec-conformance suites), `tsc` clean, `eslint` clean. Handler unit tests were updated only where they asserted `Promise`-wrapped returns (`Promise.resolve(...)`-wrapping in expectations); no expected values changed.

## Relationship to other open work

- Supersedes/extends upstream draft rubensworks/jsonld-streaming-parser.js#150 (its commit is the first commit here).
- Complements rubensworks/jsonld-streaming-parser.js#151 (injectable context parser) and rubensworks/jsonld-context-parser.js#85 (opt-in normalized-context cache): workload 1 above measures what that combination enables.

---
Generated by an agent (Claude Fable 5) on @jeswr's behalf — staged on this fork for his review before upstreaming.



> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).